### PR TITLE
Set selinux shared labels on mounts

### DIFF
--- a/utilities/lab-build
+++ b/utilities/lab-build
@@ -5,7 +5,7 @@ echo "Starting build process..."
 echo "Removing old site..."
 rm -rf ./www/*
 echo "Building new site..."
-podman run --rm --name showroom-builder --platform linux/amd64 -v "./:/antora" docker.io/antora/antora default-site.yml
+podman run --rm --name showroom-builder --platform linux/amd64 -v "./:/antora:z" docker.io/antora/antora default-site.yml
 echo "Build process complete. Check the ./www folder for the generated site."
 echo "To view the site locally, run the following command: utilities/lab-serve"
 echo "If already running then browse to http://localhost:8443/index.html"


### PR DESCRIPTION
When running locally, both the build container and the serving container need to be able to access files from the working directory. Add a :z onto the mount options so that podman sets selinux labels correctly and the build process can read all of the files.