### PR TITLE
Version formatting and quota clarity

### DIFF
--- a/content/modules/ROOT/pages/100-setup/custom-domain-private-cluster.adoc
+++ b/content/modules/ROOT/pages/100-setup/custom-domain-private-cluster.adoc
@@ -316,7 +316,7 @@ az aro create \
 [source,bash,subs="+macros,+attributes",role=execute]
 ----
 az aro get-versions
-export AZR_OCP_VERSION=$(az aro get-versions -ojson --query '[0]')
+export AZR_OCP_VERSION=$(az aro get-versions -ojson --query '[0]' -o tsv)
 echo "export AZR_OCP_VERSION=$AZR_OCP_VERSION" >> ~/.bashrc
 echo $AZR_OCP_VERSION
 ----

--- a/content/modules/ROOT/pages/100-setup/environment-setup.adoc
+++ b/content/modules/ROOT/pages/100-setup/environment-setup.adoc
@@ -235,7 +235,7 @@ az account show --subscription $AZ_SUB_ID --query name -o tsv
 .. Set *Subscription* to the name of the subscription you are creating the cluster in
 .. Set *Region* to "East US" and uncheck the other region boxes
 . Search for the quota name that you want to increase.
-This may be "Total Regional vCPUs" if you checked that prior to creating the cluster, or it may be a specific resource quota named in a `ResourceQuotaExceeded` error message.
+This may be "Standard DSv3 Family vCPUs" if you checked that prior to creating the cluster, or it may be a specific resource quota named in a `ResourceQuotaExceeded` error message.
 Note that in the latter case, the Azure console uses a localized display name (for example `Standard DSv3 Family vCPUs` rather than an identifier name `standardDSv3Family` mentioned in the error message.
 . Next to the quota name you wish to increase, click the pencil in the Adjustable column to request adjustment
 . Enter the new desired quota in the *New limit* text box.


### PR DESCRIPTION
* Add `-o tsv` to `az aro list-versions` to prevent the value from being quoted and rejected with `--version is invalid` from `az aro create`
* Clarify which quota students should be bumping