### PR TITLE
Tweaks to AAD instructions

### DIFF
--- a/content/antora.yml
+++ b/content/antora.yml
@@ -7,6 +7,7 @@ nav:
 asciidoc:
   attributes:
     guid: my-guid
+    experimental: true
 
   extensions:
     - ./content/lib/tab-block.js

--- a/content/modules/ROOT/pages/100-setup/azuread-aro.adoc
+++ b/content/modules/ROOT/pages/100-setup/azuread-aro.adoc
@@ -101,12 +101,12 @@ oc login \
   -p $(az aro list-credentials -g $AZR_RESOURCE_GROUP -n $AZR_CLUSTER --query kubeadminPassword -o tsv)
 ----
 +
-. Next, create a secret that contains the client secret that you captured in step 2 above.
+. Next, create a secret that contains the client secret value that you captured in step 2 above.
 To do so, run the following command, making sure to replace the variable specified:
 +
 [source,bash,subs="+macros,+attributes",role=execute]
 ----
-CLIENT_SECRET=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # Replace this with the Client Secret
+CLIENT_SECRET=xxxxxxx # Replace this with the Client Secret Value
 ----
 +
 [source,bash,subs="+macros,+attributes",role=execute]


### PR DESCRIPTION
* Turn on support for experimental asciidoc syntax to allow btn syntax to render
* Clarify that when generating a client secret, students want the client secret value and not its ID