### PR TITLE
Remove cleanup instructions for Key Vault CSI

### DIFF
--- a/content/modules/ROOT/pages/100-setup/azure-key-vault.adoc
+++ b/content/modules/ROOT/pages/100-setup/azure-key-vault.adoc
@@ -224,6 +224,7 @@ Output should match:
 Hello
 ----
 
+////
 == Cleanup
 
 . Uninstall Helm
@@ -255,3 +256,4 @@ az ad sp delete --id ${SERVICE_PRINCIPAL_CLIENT_ID}
 ----
 
 include::uninstall-kubernetes-secret-store-driver.adoc[]
+////


### PR DESCRIPTION
Prevent students from wasting time on cleanup or accidentally cleaning up too early.

Commented out rather than deleted at jmaltin's request.